### PR TITLE
Fix transient suffix name

### DIFF
--- a/transient-showcase.el
+++ b/transient-showcase.el
@@ -272,7 +272,7 @@
 
    ;; this suffix will not exit after calling sub-prefix
    ("we" "wave & exit" tsc-wave-overridden)
-   ("ws" "wave & stay" tsc-wave :transient t)])
+   ("ws" "wave & stay" tsc-suffix-wave :transient t)])
 
 ;; (tsc-stay-transient)
 
@@ -652,7 +652,7 @@ This command can be called from it's parent, `tsc-snowcone-eater' or independent
     ("S" "inline shortarg switch" ("-n" "--inline-shortarg-switch"))]]
 
   ["Commands"
-   ("w" "wave some" tsc-wave)
+   ("w" "wave some" tsc-suffix-wave)
    ("s" "show arguments" tsc-suffix-print-args)]) ; use to analyze the switch values
 
 ;; (tsc-switches-and-arguments)


### PR DESCRIPTION
Currently, running examples `fs stay-transient` or `cb basic arguments` will cause a runtime error due to the symbol name `tsc-wave` being used instead of `tsc-suffix-wave`:

```
Debugger entered--Lisp error: (error "Suffix tsc-wave is not defined or autoloaded as a command")
  transient--exit-and-debug(error (error "Suffix tsc-wave is not defined or autoloaded as a ..."))
  error("Suffix %s is not defined or autoloaded as a comman..." tsc-wave)
  transient--ensure-infix-command(#<transient-suffix transient-suffix-4bf04668>)
  transient--init-suffix(nil (1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t)))
  transient--init-child(nil (1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t)))
  #f(compiled-function (c) #<bytecode -0x142fd9404784170e>)((1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t)))
  cl-mapcan(#f(compiled-function (c) #<bytecode -0x142fd9404784170e>) ((1 transient-suffix (:key "we" :description "wave & exit" :command tsc-wave-overridden)) (1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t))))
  transient--init-group(nil [1 transient-column (:description "Exit or Not?") ((1 transient-suffix (:key "we" :description "wave & exit" :command tsc-wave-overridden)) (1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t)))])
  transient--init-child(nil [1 transient-column (:description "Exit or Not?") ((1 transient-suffix (:key "we" :description "wave & exit" :command tsc-wave-overridden)) (1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t)))])
  #f(compiled-function (c) #<bytecode -0x142fd9404784170e>)([1 transient-column (:description "Exit or Not?") ((1 transient-suffix (:key "we" :description "wave & exit" :command tsc-wave-overridden)) (1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t)))])
  cl-mapcan(#f(compiled-function (c) #<bytecode -0x142fd9404784170e>) ([1 transient-column (:description "Exit or Not?") ((1 transient-suffix (:key "we" :description "wave & exit" :command tsc-wave-overridden)) (1 transient-suffix (:key "ws" :description "wave & stay" :command tsc-wave :transient t)))] [1 transient-columns (:hide #f(compiled-function () #<bytecode 0x173d916a38d3701e>)) ([1 transient-column (:description "Value commands") ((1 transient-suffix (:key "C-x s  " :description "Set" :command transient-set)) (1 transient-suffix (:key "C-x C-s" :description "Save" :command transient-save)) (1 transient-suffix (:key "C-x C-k" :description "Reset" :command transient-reset)) (1 transient-suffix (:key "C-x p  " :description "Previous value" :command transient-history-prev)) (1 transient-suffix (:key "C-x n  " :description "Next value" :command transient-history-next)))] [1 transient-column (:description "Sticky commands") ((1 transient-suffix (:key "C-g" :description "Quit prefix or transient" :command transient-quit-one)) (1 transient-suffix (:key "C-q" :description "Quit transient stack" :command transient-quit-all)) (1 transient-suffix (:key "C-z" :description "Suspend transient stack" :command transient-suspend)))] [1 transient-column (:description "Customize") ((1 transient-suffix (:key "C-x t" :command transient-toggle-common :description #f(compiled-function () #<bytecode 0x1e0d324363ac0fb5>))) (1 transient-suffix (:key "C-x l" :description "Show/hide suffixes" :command transient-set-level)))])]))
  transient--init-suffixes(tsc-stay-transient)
  transient--init-objects(tsc-stay-transient nil nil)
  transient-setup(tsc-stay-transient)
  (closure (t) nil (interactive) (transient-setup 'tsc-stay-transient))()
  apply((closure (t) nil (interactive) (transient-setup 'tsc-stay-transient)) nil)
  #f(compiled-function (fn &rest args) #<bytecode -0x1bb8f1d2f2e8f063>)((closure (t) nil (interactive) (transient-setup 'tsc-stay-transient)))
  apply(#f(compiled-function (fn &rest args) #<bytecode -0x1bb8f1d2f2e8f063>) (closure (t) nil (interactive) (transient-setup 'tsc-stay-transient)) nil)
  (lambda (fn &rest args) (interactive #f(compiled-function (spec) #<bytecode 0x14ea9a8c69c41c8e>)) (apply '#f(compiled-function (fn &rest args) #<bytecode -0x1bb8f1d2f2e8f063>) fn args))((closure (t) nil (interactive) (transient-setup 'tsc-stay-transient)))
  apply((lambda (fn &rest args) (interactive #f(compiled-function (spec) #<bytecode 0x14ea9a8c69c41c8e>)) (apply '#f(compiled-function (fn &rest args) #<bytecode -0x1bb8f1d2f2e8f063>) fn args)) (closure (t) nil (interactive) (transient-setup 'tsc-stay-transient)) nil)
  tsc-stay-transient()
  funcall-interactively(tsc-stay-transient)
  command-execute(tsc-stay-transient)
```

This PR fixes the symbol name.