### PR TITLE
Fix transient suffix name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.2.0
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/transient-showcase.el
+++ b/transient-showcase.el
@@ -272,7 +272,7 @@
 
    ;; this suffix will not exit after calling sub-prefix
    ("we" "wave & exit" tsc-wave-overridden)
-   ("ws" "wave & stay" tsc-wave :transient t)])
+   ("ws" "wave & stay" tsc-suffix-wave :transient t)])
 
 ;; (tsc-stay-transient)
 
@@ -652,7 +652,7 @@ This command can be called from it's parent, `tsc-snowcone-eater' or independent
     ("S" "inline shortarg switch" ("-n" "--inline-shortarg-switch"))]]
 
   ["Commands"
-   ("w" "wave some" tsc-wave)
+   ("w" "wave some" tsc-suffix-wave)
    ("s" "show arguments" tsc-suffix-print-args)]) ; use to analyze the switch values
 
 ;; (tsc-switches-and-arguments)


### PR DESCRIPTION
Been a bit of disparity between PR's started in the repo and from forks.  Evidently PR's within repo were broken by settings.  Correcting.