### PR TITLE
Fix: transient-showcase.el:188:2: Error: Invalid transient--parse-chi…

### DIFF
--- a/transient-showcase.el
+++ b/transient-showcase.el
@@ -192,7 +192,7 @@
      (:info #'tsc--random-info)
      (:info "Use :format to remove whitespace" :format "%d")
      ("k" :info "Keys will be greyed out")
-     () ; empty line
+     ;; () ; empty line
      ("wg" "wave greenishly" tsc-suffix-wave)])
 
 (transient-define-prefix tsc-layout-stacked ()


### PR DESCRIPTION
Fix error prompted upon `(require transient-showcase)` on GNU Emacs 29.1 with Spacemacs.

    In toplevel form:
    transient-showcase.el:188:2: Error: Invalid transient--parse-child spec: nil
